### PR TITLE
feat: Support 1.17 or later

### DIFF
--- a/.github/workflows/deploy-docker-image.yaml
+++ b/.github/workflows/deploy-docker-image.yaml
@@ -1,0 +1,37 @@
+on:
+  push:
+    tags:
+      - 'v*'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata for Docker image
+        id: metadata
+        uses: docker/metadata-action@v5
+        with:
+          images: "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          tags: ${{ steps.metadata.outputs.tags }}
+          labels: ${{ steps.metadata.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
-FROM alpine
+FROM debian:bookworm-slim
 
-RUN apk --update add git openjdk8 openjdk17 wget maven && \
-    rm -rf /var/lib/apt/lists/* && \
-    rm /var/cache/apk/*
+# openjdk-8-jdk は Stable ではサポートされないので sid から取得する
+RUN echo "deb http://deb.debian.org/debian/ sid main" | tee -a /etc/apt/sources.list
+RUN apt update && apt install -y git wget maven openjdk-17-jdk openjdk-8-jdk
 
 COPY entrypoint.sh entrypoint.sh
 RUN chmod +x entrypoint.sh
+ENV M2_HOME=/usr/share/maven
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM alpine
 
-# Install git and java 8
-RUN apk --update add git openjdk8 wget && \
+RUN apk --update add git openjdk8 openjdk16 openjdk17 wget && \
     rm -rf /var/lib/apt/lists/* && \
     rm /var/cache/apk/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine
 
-RUN apk --update add git openjdk8 openjdk17 wget && \
+RUN apk --update add git openjdk8 openjdk17 wget maven && \
     rm -rf /var/lib/apt/lists/* && \
     rm /var/cache/apk/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine
 
-RUN apk --update add git openjdk8 openjdk16 openjdk17 wget && \
+RUN apk --update add git openjdk8 openjdk17 wget && \
     rm -rf /var/lib/apt/lists/* && \
     rm /var/cache/apk/*
 

--- a/README.md
+++ b/README.md
@@ -2,13 +2,12 @@
 
 This action builds NMS and adds artifacts to `$WORKSPACE/nms-build`.
 
-
 # Usage
 
 ```yaml
-- uses: derongan/nmsaction@v1
+- uses: PeyaPeyaPeyang/nmsaction@v1
   with:
-    rev: 1.15.2
+    rev: 1.19.4 # This fork supports versions 1.17 or later
 - name: Install nms into m2
-  	run: mkdir -p $HOME/.m2/repository && cp -a nms-build/.m2/repository/. $HOME/.m2/repository
+    run: mkdir -p $HOME/.m2/repository && cp -a nms-build/.m2/repository/. $HOME/.m2/repository
 ```

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,6 @@ inputs:
     default: '1.15.2'
 runs:
   using: 'docker'
-  image: 'Dockerfile'
+  image: 'docker://ghcr.io/peyapeyapeyang/nmsaction:latest'
   args:
     - ${{ inputs.rev }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,25 +1,17 @@
 #!/bin/sh
 
-# Function to install dependencies
-build_one_nms() {
-    version=$1
-
-    # Create directory for build
-    mkdir -p "nms-build/${version//./_}"
-    if [ $? -ne 0 ]; then
-        echo "Error: Failed to create directory for version $version"
-        return 1
-    fi
-    cd "nms-build/${version//./_}" || return 1
-
+download_build_tools() {
     # Download BuildTools.jar
     wget -O BuildTools.jar "https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar"
     if [ $? -ne 0 ]; then
         echo "Error: Failed to download BuildTools.jar for version $version"
-        cd ..
         return 1
     fi
+}
 
+# Function to install dependencies
+build_one_nms() {
+    version=$1
     # Determine Java version based on provided Minecraft version
     case $version in
         1.17 | 1.16* | 1.15* | 1.14* | 1.13* | 1.12* | 1.11* | 1.10* | 1.9* | 1.8*)
@@ -42,11 +34,8 @@ build_one_nms() {
     "$JAVA_EXE" -jar BuildTools.jar --rev "$version"
     if [ $? -ne 0 ]; then
         echo "Error: Failed to build version $version"
-        cd ..
         return 1
     fi
-
-    cd ../..
 }
 
 # Check if versions are provided as arguments
@@ -58,17 +47,24 @@ fi
 # Join the comma-separated list into a space-separated list
 version_list=$(echo "$*" | tr ',' ' ')
 
+# Create directory for build
+mkdir -p "nms-build"
+cd "nms-build" || exit 1
+
+# Download BuildTools.jar
+download_build_tools || exit 1
+
 # Iterate through provided versions
 for version in $version_list; do
     build_one_nms "$version" || exit 1
 done
 
 # Install to github .m2
-mkdir -p nms-build/.m2/repository
+mkdir -p .m2/repository
 if [ $? -ne 0 ]; then
     echo "Error: Failed to create .m2/repository directory"
     exit 1
 fi
 
 # Deploy to local
-cp -r /root/.m2/repository/. nms-build/.m2/repository || exit 1
+cp -r /root/.m2/repository .m2/repository || exit 1

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,9 +9,32 @@ download_build_tools() {
     fi
 }
 
+ get_arch() {
+     jvm_dir="/usr/lib/jvm/"
+
+     # パターンに一致するファイルが存在するかチェック
+     files=$(ls -d "$jvm_dir"java-[0-9]*-openjdk-* 2>/dev/null)
+     if [ -z "$files" ]; then
+         echo "No OpenJDK installation found in $jvm_dir" >&2
+         return 1
+     fi
+
+     # パターンに一致するファイル名を取得し、パターンに一致する部分を抽出して出力
+     for file in $files; do
+         if echo "$file" | grep -qE "java-[0-9]+-openjdk-[^-]+$"; then
+             arch=$(basename "$file" | sed -E "s/.*java-[0-9]+-openjdk-([^-]+)$/\1/")
+             echo "$arch"
+             return 0
+         fi
+     done
+
+     return 1
+ }
+
+
 # Function to install dependencies
 build_one_nms() {
-    cpu_arch_type=$(lscpu | grep Architecture | awk {'print $2'})
+    cpu_arch_type=$(get_arch)
     version=$1
     # Determine Java version based on provided Minecraft version
     case $version in

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,16 +11,17 @@ download_build_tools() {
 
 # Function to install dependencies
 build_one_nms() {
+    cpu_arch_type=$(lscpu | grep Architecture | awk {'print $2'})
     version=$1
     # Determine Java version based on provided Minecraft version
     case $version in
         1.17 | 1.16* | 1.15* | 1.14* | 1.13* | 1.12* | 1.11* | 1.10* | 1.9* | 1.8*)
             echo "Using java8"
-            export JAVA_HOME=/usr/lib/jvm/java-8-openjdk
+            export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-$cpu_arch_type
             ;;
         *)
             echo "Using java17"
-            export JAVA_HOME=/usr/lib/jvm/java-17-openjdk
+            export JAVA_HOME=/usr/lib/jvm/java-17-openjdk-$cpu_arch_type
             ;;
     esac
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,14 +7,9 @@ wget -O BuildTools.jar https://hub.spigotmc.org/jenkins/job/BuildTools/lastSucce
 version=$1
 
 # Older than 1.17 is java8
-# 1.17.1 is java16
 # Newer than 1.17.1 is java17
 case $version in
-  1.17.1)
-    echo "Using java16"
-    export JAVA_HOME=/usr/lib/jvm/java-16-openjdk
-    ;;
- 1.17* | 1.16* | 1.15* | 1.14* | 1.13* | 1.12* | 1.11* | 1.10* | 1.9* | 1.8*)
+ 1.17 | 1.16* | 1.15* | 1.14* | 1.13* | 1.12* | 1.11* | 1.10* | 1.9* | 1.8*)
     echo "Using java8"
     export JAVA_HOME=/usr/lib/jvm/java-8-openjdk
     ;;

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,7 +4,34 @@ cd nms-build
 
 wget -O BuildTools.jar https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar
 
-java -jar BuildTools.jar --rev $1
+version=$1
+
+# Older than 1.17 is java8
+# 1.17.1 is java16
+# Newer than 1.17.1 is java17
+case $version in
+  1.17.1)
+    echo "Using java16"
+    export JAVA_HOME=/usr/lib/jvm/java-16-openjdk
+    ;;
+ 1.17* | 1.16* | 1.15* | 1.14* | 1.13* | 1.12* | 1.11* | 1.10* | 1.9* | 1.8*)
+    echo "Using java8"
+    export JAVA_HOME=/usr/lib/jvm/java-8-openjdk
+    ;;
+  *)
+    echo "Using java17"
+    export JAVA_HOME=/usr/lib/jvm/java-17-openjdk
+    ;;
+esac
+
+# Set the JAVA_EXE variable
+JAVA_EXE=$JAVA_HOME/bin/java
+
+echo "Using java: $JAVA_HOME"
+echo "Using Java executable: $JAVA_EXE"
+
+# Run BuildTools.jar with the specified version
+$JAVA_EXE -jar BuildTools.jar --rev $version
 
 # Install to github .m2
 mkdir -p .m2/repository

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,39 +1,74 @@
-#!/bin/sh -l
+#!/bin/sh
 
 # Function to install dependencies
-install_dependencies() {
-    # Create directory for build
-    mkdir nms-build
-    cd nms-build
-
-    # Download BuildTools.jar
-    wget -O BuildTools.jar https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar
-
+build_one_nms() {
     version=$1
 
-    # Determine Java version based on provided Minecraft version
-    if [[ $version == 1.17* || $version == 1.16* || $version == 1.15* || $version == 1.14* || $version == 1.13* || $version == 1.12* || $version == 1.11* || $version == 1.10* || $version == 1.9* || $version == 1.8* ]]; then
-        echo "Using java8"
-        export JAVA_HOME=/usr/lib/jvm/java-8-openjdk
-    else
-        echo "Using java17"
-        export JAVA_HOME=/usr/lib/jvm/java-17-openjdk
+    # Create directory for build
+    mkdir -p "nms-build/${version//./_}"
+    if [ $? -ne 0 ]; then
+        echo "Error: Failed to create directory for version $version"
+        return 1
+    fi
+    cd "nms-build/${version//./_}" || return 1
+
+    # Download BuildTools.jar
+    wget -O BuildTools.jar "https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar"
+    if [ $? -ne 0 ]; then
+        echo "Error: Failed to download BuildTools.jar for version $version"
+        cd ..
+        return 1
     fi
 
+    # Determine Java version based on provided Minecraft version
+    case $version in
+        1.17 | 1.16* | 1.15* | 1.14* | 1.13* | 1.12* | 1.11* | 1.10* | 1.9* | 1.8*)
+            echo "Using java8"
+            export JAVA_HOME=/usr/lib/jvm/java-8-openjdk
+            ;;
+        *)
+            echo "Using java17"
+            export JAVA_HOME=/usr/lib/jvm/java-17-openjdk
+            ;;
+    esac
+
     # Set the JAVA_EXE variable
-    JAVA_EXE=$JAVA_HOME/bin/java
+    JAVA_EXE="$JAVA_HOME/bin/java"
 
     echo "Using java: $JAVA_HOME"
     echo "Using Java executable: $JAVA_EXE"
 
     # Run BuildTools.jar with the specified version
-    $JAVA_EXE -jar BuildTools.jar --rev $version
+    "$JAVA_EXE" -jar BuildTools.jar --rev "$version"
+    if [ $? -ne 0 ]; then
+        echo "Error: Failed to build version $version"
+        cd ..
+        return 1
+    fi
 
-    # Install to github .m2
-    mkdir -p .m2/repository
-    echo "Copying from /root/.m2/repository to $PWD/.m2/repository"
-    cp -a /root/.m2/repository/. .m2/repository
+    cd ..
 }
 
-# Call the function with the version argument passed to the script
-install_dependencies $1
+# Check if versions are provided as arguments
+if [ "$#" -eq 0 ]; then
+    echo "No versions provided. Please provide versions as comma-separated list."
+    exit 1
+fi
+
+# Join the comma-separated list into a space-separated list
+version_list=$(echo "$*" | tr ',' ' ')
+
+# Iterate through provided versions
+for version in $version_list; do
+    build_one_nms "$version" || exit 1
+done
+
+# Install to github .m2
+mkdir -p nms-build/.m2/repository
+if [ $? -ne 0 ]; then
+    echo "Error: Failed to create .m2/repository directory"
+    exit 1
+fi
+
+# Deploy to local
+cp -r /root/.m2/repository/. nms-build/.m2/repository || exit 1

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,34 +1,39 @@
 #!/bin/sh -l
-mkdir nms-build
-cd nms-build
 
-wget -O BuildTools.jar https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar
+# Function to install dependencies
+install_dependencies() {
+    # Create directory for build
+    mkdir nms-build
+    cd nms-build
 
-version=$1
+    # Download BuildTools.jar
+    wget -O BuildTools.jar https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar
 
-# Older than 1.17 is java8
-# Newer than 1.17.1 is java17
-case $version in
- 1.17 | 1.16* | 1.15* | 1.14* | 1.13* | 1.12* | 1.11* | 1.10* | 1.9* | 1.8*)
-    echo "Using java8"
-    export JAVA_HOME=/usr/lib/jvm/java-8-openjdk
-    ;;
-  *)
-    echo "Using java17"
-    export JAVA_HOME=/usr/lib/jvm/java-17-openjdk
-    ;;
-esac
+    version=$1
 
-# Set the JAVA_EXE variable
-JAVA_EXE=$JAVA_HOME/bin/java
+    # Determine Java version based on provided Minecraft version
+    if [[ $version == 1.17* || $version == 1.16* || $version == 1.15* || $version == 1.14* || $version == 1.13* || $version == 1.12* || $version == 1.11* || $version == 1.10* || $version == 1.9* || $version == 1.8* ]]; then
+        echo "Using java8"
+        export JAVA_HOME=/usr/lib/jvm/java-8-openjdk
+    else
+        echo "Using java17"
+        export JAVA_HOME=/usr/lib/jvm/java-17-openjdk
+    fi
 
-echo "Using java: $JAVA_HOME"
-echo "Using Java executable: $JAVA_EXE"
+    # Set the JAVA_EXE variable
+    JAVA_EXE=$JAVA_HOME/bin/java
 
-# Run BuildTools.jar with the specified version
-$JAVA_EXE -jar BuildTools.jar --rev $version
+    echo "Using java: $JAVA_HOME"
+    echo "Using Java executable: $JAVA_EXE"
 
-# Install to github .m2
-mkdir -p .m2/repository
-echo "Copying from /root/.m2/repository to $PWD/.m2/repository"
-cp -a /root/.m2/repository/. .m2/repository
+    # Run BuildTools.jar with the specified version
+    $JAVA_EXE -jar BuildTools.jar --rev $version
+
+    # Install to github .m2
+    mkdir -p .m2/repository
+    echo "Copying from /root/.m2/repository to $PWD/.m2/repository"
+    cp -a /root/.m2/repository/. .m2/repository
+}
+
+# Call the function with the version argument passed to the script
+install_dependencies $1

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -46,7 +46,7 @@ build_one_nms() {
         return 1
     fi
 
-    cd ..
+    cd ../..
 }
 
 # Check if versions are provided as arguments


### PR DESCRIPTION
# Abstraction

Supports NMS builds of Minecraft v1.17 or higher versions.

# Description

Currently, the following error occurs when attempting to build a version of NMS greater than v1.17.
This simple PR supports the latest Minecraft by automatically selecting the Java version at build time.

```
openjdk version "1.8.0_372"
OpenJDK Runtime Environment (IcedTea 3.27.0) (Alpine 8.372.07-r0)
OpenJDK 64-Bit Server VM (build 25.372-b07, mixed mode)
Attempting to build version: '1.19.4' use --rev <version> to override
Found version
{
	"name": "3763",
	"description": "Jenkins build 3763",
	"refs": {
		"BuildData": "4d9436f7b66190ad21fe4e3975b73a36b7ad2a7e",
		"Bukkit": "5dbedae1cbbc70791dcfc374c4c8da35db309a44",
		"CraftBukkit": "5a5e43ee6bab92419f7a7cfdb39af61a74b226ab",
		"Spigot": "7d7b241e353e86ee90ad025dab0262b050a6fe4a"
	},
	"toolsVersion": 148,
	"javaVersions": [61, 64]
}

*** The version you have requested to build requires Java versions between [Java 17, Java 20], but you are using Java 8
*** Please rerun BuildTools using an appropriate Java version. For obvious reasons outdated MC versions do not support Java versions that did not exist at their release.
```

According to the [Spigot documentation](https://www.spigotmc.org/wiki/buildtools/#prerequisites), less than 1.17.1 should use java 8, 1.17.1 should use java 16, and newer versions than that should use java 17, so I followed that.